### PR TITLE
Added support to touchscreen event on DaFunk::Helper#menu

### DIFF
--- a/lib/da_funk/helper.rb
+++ b/lib/da_funk/helper.rb
@@ -303,7 +303,10 @@ module DaFunk
 
     # TODO Scalone: Refactor.
     def pagination(title, options, collection, &block)
+      timeout = Device::IO.timeout
+      touchscreen_options = {}
       start_line, options[:limit], options[:header] = pagination_limit(title, options)
+
       if collection.size > (options[:limit] - options[:header]) # minus pagination header
         key   = Device::IO.back_key
         pages = pagination_page(collection, options[:limit] - options[:header]) # minus pagination header
@@ -313,7 +316,13 @@ module DaFunk
           pagination_header(title, page, pages.size, start_line, options[:default], options[:header])
           values = pages[page].to_a
           block.call(values, start_line + options[:header])
-          key  = try_key(pagination_keys(values.size, true))
+
+          params = {special_keys: pagination_keys(values.size, true)}
+          if options.include?(:touchscreen_options)
+            touchscreen_options = options[:touchscreen_options]
+          end
+
+          event, key = wait_touchscreen_or_keyboard_event(touchscreen_options, timeout, params)
           page = pagination_key_page(page, key, pages.size)
         end
       else
@@ -321,7 +330,8 @@ module DaFunk
         print_title(title, options[:default]) if title
         values = collection.to_a
         block.call(values, start_line)
-        key = try_key(pagination_keys(collection.size, false))
+        params = {special_keys: pagination_keys(collection.size, false)}
+        event, key = wait_touchscreen_or_keyboard_event(touchscreen_options, timeout, params)
       end
       result = values[key.to_i-1] if key.integer?
       if result.is_a? Array

--- a/lib/da_funk/helper.rb
+++ b/lib/da_funk/helper.rb
@@ -322,7 +322,7 @@ module DaFunk
             touchscreen_options = options[:touchscreen_options]
           end
 
-          event, key = wait_touchscreen_or_keyboard_event(touchscreen_options, timeout, params)
+          _, key = wait_touchscreen_or_keyboard_event(touchscreen_options, timeout, params)
           page = pagination_key_page(page, key, pages.size)
         end
       else
@@ -331,7 +331,7 @@ module DaFunk
         values = collection.to_a
         block.call(values, start_line)
         params = {special_keys: pagination_keys(collection.size, false)}
-        event, key = wait_touchscreen_or_keyboard_event(touchscreen_options, timeout, params)
+        _, key = wait_touchscreen_or_keyboard_event(touchscreen_options, timeout, params)
       end
       result = values[key.to_i-1] if key.integer?
       if result.is_a? Array


### PR DESCRIPTION
We need a menu that has support to both text and image background with also touchscreen and keyboard, like this;
![20200612_121401](https://user-images.githubusercontent.com/53445038/84518009-6a86f700-aca6-11ea-9bfa-a0e8fa00524d.jpg)

We already have this on ```DaFunk::Helper#menu``` but It was working with keyboard only, using ```DaFunk::Helper#try_key```. So. I just replaced try_key call to ```DaFunk::Helper#wait_touchscreen_or_keyboard_event``` which waits for touchscreen or keyboard event.