### PR TITLE
Add main version on settings

### DIFF
--- a/lib/da_funk/params_dat.rb
+++ b/lib/da_funk/params_dat.rb
@@ -151,10 +151,14 @@ module DaFunk
 
     def self.restart
       Device::Display.clear
-      I18n.pt(:admin_main_update_message)
-      3.times do |i|
-        Device::Display.print("REBOOTING IN #{3 - i}",3,3)
-        sleep(1)
+      if File.exists?('./shared/init_reboot.bmp')
+        Device::Display.print_bitmap('./shared/init_reboot.bmp')
+      else
+        I18n.pt(:admin_main_update_message)
+        3.times do |i|
+          Device::Display.print("REBOOTING IN #{3 - i}",3,3)
+          sleep(1)
+        end
       end
       Device::System.restart
     end

--- a/lib/device/setting.rb
+++ b/lib/device/setting.rb
@@ -67,7 +67,8 @@ class Device
       "transaction_http_host"       => HTTP_HOST_PRODUCTION,
       "transaction_http_port"       => HTTP_PORT,
       "emv_contactless_amount"      => "0",
-      "network_init"                => ""
+      "network_init"                => "",
+      "main_app_version"            => ""
     }
 
     class << self


### PR DESCRIPTION
- When main application is updated is better to show a beautiful screen instead text screen
- In some situations is necessary to know main application version in the payment application context