### PR TITLE
Fix battery charging status

### DIFF
--- a/lib/da_funk/helper/status_bar.rb
+++ b/lib/da_funk/helper/status_bar.rb
@@ -146,8 +146,13 @@ module DaFunk
           self.battery = bat
           self.power   = dock
 
-          Device::Display.print_status_bar(SLOT_BATTERY_PERCENTUAL,
-                                           get_image_path(:battery_percentual, self.battery))
+          if self.power && self.battery == 50
+            Device::Display.print_status_bar(SLOT_BATTERY_PERCENTUAL, nil)
+          else
+            percentual = get_image_path(:battery_percentual, self.battery)
+            Device::Display.print_status_bar(SLOT_BATTERY_PERCENTUAL, percentual)
+          end
+
           if self.power
             Device::Display.print_status_bar(
               SLOT_BATTERY_LEVEL, get_image_path(:battery_charge, self.battery))


### PR DESCRIPTION
When power supply is connected the SDK always returns 50% of battery, in
this case it won't show the percentage untill the SDK returns 100%