### PR TITLE
feature/CCT-257

### DIFF
--- a/lib/da_funk/helper/status_bar.rb
+++ b/lib/da_funk/helper/status_bar.rb
@@ -1,12 +1,23 @@
+#
+# @file status_bar.rb
+# @brief DaFunk status bar helper script.
+# @platform N/A
+#
+# @copyright Copyright (c) 2016 CloudWalk, Inc.
+#
+
 module DaFunk
   module Helper
+    # Status bar class definition.
     class StatusBar
-      STATUS_TIMEOUT          = 60
-      SLOT_MEDIA              = 0
-      SLOT_SIGNAL_LEVEL       = 1
-      SLOT_UPDATE             = 2
+      # Class macros and constants
+      STATUS_TIMEOUT = 60
+      SLOT_MEDIA = 0
+      SLOT_SIGNAL_LEVEL = 1
+      SLOT_UPDATE = 2
       SLOT_BATTERY_PERCENTUAL = 6
-      SLOT_BATTERY_LEVEL      = 7
+      SLOT_BATTERY_LEVEL = 7
+
       SLOT_MESSAGE_CONNECTION = {
         true  => {
           :slot1 => 2,
@@ -22,9 +33,52 @@ module DaFunk
         }
       }
 
+      # TODO: review the 'print_status_bar' API to reduce the number of files
+      # to eleven?
+      BATTERY_PERCENTAGE_IMAGES = [
+         './shared/0%.png',  './shared/1%.png',  './shared/2%.png',
+         './shared/3%.png',  './shared/4%.png',  './shared/5%.png',
+         './shared/6%.png',  './shared/7%.png',  './shared/8%.png',
+         './shared/9%.png', './shared/10%.png', './shared/11%.png',
+        './shared/12%.png', './shared/13%.png', './shared/14%.png',
+        './shared/15%.png', './shared/16%.png', './shared/17%.png',
+        './shared/18%.png', './shared/19%.png', './shared/20%.png',
+        './shared/21%.png', './shared/22%.png', './shared/23%.png',
+        './shared/24%.png', './shared/25%.png', './shared/26%.png',
+        './shared/27%.png', './shared/28%.png', './shared/29%.png',
+        './shared/30%.png', './shared/31%.png', './shared/32%.png',
+        './shared/33%.png', './shared/34%.png', './shared/35%.png',
+        './shared/36%.png', './shared/37%.png', './shared/38%.png',
+        './shared/39%.png', './shared/40%.png', './shared/41%.png',
+        './shared/42%.png', './shared/43%.png', './shared/44%.png',
+        './shared/45%.png', './shared/46%.png', './shared/47%.png',
+        './shared/48%.png', './shared/49%.png', './shared/50%.png',
+        './shared/51%.png', './shared/52%.png', './shared/53%.png',
+        './shared/54%.png', './shared/55%.png', './shared/56%.png',
+        './shared/57%.png', './shared/58%.png', './shared/59%.png',
+        './shared/60%.png', './shared/61%.png', './shared/62%.png',
+        './shared/63%.png', './shared/64%.png', './shared/65%.png',
+        './shared/66%.png', './shared/67%.png', './shared/68%.png',
+        './shared/69%.png', './shared/70%.png', './shared/71%.png',
+        './shared/72%.png', './shared/73%.png', './shared/74%.png',
+        './shared/75%.png', './shared/76%.png', './shared/77%.png',
+        './shared/78%.png', './shared/79%.png', './shared/80%.png',
+        './shared/81%.png', './shared/82%.png', './shared/83%.png',
+        './shared/84%.png', './shared/85%.png', './shared/86%.png',
+        './shared/87%.png', './shared/88%.png', './shared/89%.png',
+        './shared/90%.png', './shared/91%.png', './shared/92%.png',
+        './shared/93%.png', './shared/94%.png', './shared/95%.png',
+        './shared/96%.png', './shared/97%.png', './shared/98%.png',
+        './shared/99%.png', './shared/100%.png'
+      ].freeze
+
+      BATTERY_CHARGING = [
+        "./shared/battery_charging.png",
+        "./shared/battery_charged.png"
+      ].freeze
+
       BATTERY_IMAGES = {
-        0..4     => "./shared/battery0.png",
-        5..9     => "./shared/baterry5.png",
+        0..9     => "./shared/battery0.png",
         10..19   => "./shared/battery10.png",
         20..29   => "./shared/battery20.png",
         30..39   => "./shared/battery30.png",
@@ -34,44 +88,24 @@ module DaFunk
         70..79   => "./shared/battery70.png",
         80..89   => "./shared/battery80.png",
         90..99   => "./shared/battery90.png",
-        100..100 => "./shared/battery100.png",
-      }
-
-      BATTERY_CHARGE_IMAGES = {
-        50  => "./shared/battery0c.png",
-        100 => "./shared/battery100c.png"
-      }
-
-      BATTERY_PERCENTAGE_IMAGES = {
-        0..4     => "./shared/battery1_percent.png",
-        5..9     => "./shared/battery5_percent.png",
-        10..19   => "./shared/battery10_percent.png",
-        20..29   => "./shared/battery20_percent.png",
-        30..39   => "./shared/battery30_percent.png",
-        40..49   => "./shared/battery40_percent.png",
-        50..59   => "./shared/battery50_percent.png",
-        60..69   => "./shared/battery60_percent.png",
-        70..79   => "./shared/battery70_percent.png",
-        80..89   => "./shared/battery80_percent.png",
-        90..99   => "./shared/battery90_percent.png",
-        100..100 => "./shared/battery100_percent.png",
+        100..100 => "./shared/battery100.png"
       }
 
       WIFI_IMAGES = {
-        0..0    => "./shared/wifi0.png",
-        1..25   => "./shared/wifi25.png",
-        26..50  => "./shared/wifi50.png",
-        59..75  => "./shared/wifi75.png",
-        76..200 => "./shared/wifi100.png"
+        0..0     => "./shared/wifi0.png",
+        1..25    => "./shared/wifi25.png",
+        26..50   => "./shared/wifi50.png",
+        59..75   => "./shared/wifi75.png",
+        76..200  => "./shared/wifi100.png"
       }
 
       MOBILE_IMAGES = {
-        0..0    => "./shared/mobile0.png",
-        1..20   => "./shared/mobile20.png",
-        21..40  => "./shared/mobile40.png",
-        41..60  => "./shared/mobile60.png",
-        61..80  => "./shared/mobile80.png",
-        81..200 => "./shared/mobile100.png"
+        0..0     => "./shared/mobile0.png",
+        1..20    => "./shared/mobile20.png",
+        21..40   => "./shared/mobile40.png",
+        41..60   => "./shared/mobile60.png",
+        61..80   => "./shared/mobile80.png",
+        81..200  => "./shared/mobile100.png"
       }
 
       class << self
@@ -92,7 +126,7 @@ module DaFunk
           PAX::Display.print_status_bar(3, nil)
           self.connected = false
         else
-          change_message
+          self.change_message
         end
       end
 
@@ -124,12 +158,10 @@ module DaFunk
 
             if Device::Network.gprs?
               Device::Display.print_status_bar(SLOT_MEDIA, "./shared/GPRS.png")
-              Device::Display.print_status_bar(SLOT_SIGNAL_LEVEL,
-                                               get_image_path(:gprs, self.signal))
+              Device::Display.print_status_bar(SLOT_SIGNAL_LEVEL, self.get_image_path(:gprs, self.signal))
             elsif Device::Network.wifi?
               Device::Display.print_status_bar(SLOT_MEDIA, "./shared/WIFI.png")
-              Device::Display.print_status_bar(SLOT_SIGNAL_LEVEL,
-                                               get_image_path(:wifi, self.signal))
+              Device::Display.print_status_bar(SLOT_SIGNAL_LEVEL, self.get_image_path(:wifi, self.signal))
             end
           end
         else
@@ -138,50 +170,61 @@ module DaFunk
         end
       end
 
+      # Updates the battery slot whenever a capacity or power supply change is
+      # detected.
       def self.change_battery
-        bat  = Device::System.battery
-        dock = Device::System.power_supply
+        capacity_type = Device::System.battery_capacity_type
 
-        if self.battery != bat || self.power != dock
-          self.battery = bat
-          self.power   = dock
+        capacity = Device::System.battery
+        charging = Device::System.power_supply
 
-          if self.power && self.battery == 50
-            Device::Display.print_status_bar(SLOT_BATTERY_PERCENTUAL, nil)
-          else
-            percentual = get_image_path(:battery_percentual, self.battery)
-            Device::Display.print_status_bar(SLOT_BATTERY_PERCENTUAL, percentual)
-          end
+        if self.battery != capacity || self.power != charging
 
-          if self.power
-            Device::Display.print_status_bar(
-              SLOT_BATTERY_LEVEL, get_image_path(:battery_charge, self.battery))
-          else
-            Device::Display.print_status_bar(SLOT_BATTERY_LEVEL,
-                                             get_image_path(:battery, self.battery))
+          self.battery = capacity
+          self.power   = charging
+
+          rsc = self.get_image_path(self.power ? :battery_charge : :battery, self.battery)
+
+          Device::Display.print_status_bar(SLOT_BATTERY_LEVEL, rsc)
+
+          if capacity_type == 'percentage'
+            rsc = self.get_image_path(:battery_percentual, self.battery)
+
+            Device::Display.print_status_bar(SLOT_BATTERY_PERCENTUAL, rsc)
           end
         end
       end
 
+      # Searches for the correspondent image to 'type' and 'signal strength'.
       def self.get_image_path(type, sig)
         return if sig.nil?
         case type
         when :gprs
-          MOBILE_IMAGES.each {|k,v| return v if k.include? sig }
+          MOBILE_IMAGES.each do |k, v|
+            return v if k.include? sig
+          end
         when :wifi
-          WIFI_IMAGES.each {|k,v| return v if k.include? sig }
+          WIFI_IMAGES.each do |k, v|
+            return v if k.include? sig
+          end
         when :battery
-          BATTERY_IMAGES.each {|k,v| return v if k.include? sig }
+          BATTERY_IMAGES.each do |k, v|
+            return v if k.include? sig
+          end
         when :battery_charge
-          BATTERY_CHARGE_IMAGES[sig]
+          if sig < 100
+            BATTERY_CHARGING[0]
+          else
+            BATTERY_CHARGING[1]
+          end
         when :battery_percentual
-          BATTERY_PERCENTAGE_IMAGES.each {|k,v| return v if k.include? sig }
+          BATTERY_PERCENTAGE_IMAGES[sig]
         else
           nil
         end
       end
 
-      self.managment      ||= true
+      self.managment ||= true
       def self.valid?
         if self.managment
           true
@@ -190,4 +233,3 @@ module DaFunk
     end
   end
 end
-

--- a/lib/da_funk/helper/status_bar.rb
+++ b/lib/da_funk/helper/status_bar.rb
@@ -36,7 +36,7 @@ module DaFunk
       # TODO: review the 'print_status_bar' API to reduce the number of files
       # to eleven?
       BATTERY_PERCENTAGE_IMAGES = [
-         './shared/0%.png',  './shared/1%.png',  './shared/2%.png',
+         './shared/1%.png',  './shared/1%.png',  './shared/2%.png',
          './shared/3%.png',  './shared/4%.png',  './shared/5%.png',
          './shared/6%.png',  './shared/7%.png',  './shared/8%.png',
          './shared/9%.png', './shared/10%.png', './shared/11%.png',
@@ -78,8 +78,8 @@ module DaFunk
       ].freeze
 
       BATTERY_IMAGES = {
-        0..9     => "./shared/battery0.png",
-        10..19   => "./shared/battery10.png",
+        0..4     => "./shared/battery0.png",
+        5..19    => "./shared/battery10.png",
         20..29   => "./shared/battery20.png",
         30..39   => "./shared/battery30.png",
         40..49   => "./shared/battery40.png",
@@ -180,8 +180,15 @@ module DaFunk
 
         if self.battery != capacity || self.power != charging
 
-          self.battery = capacity
-          self.power   = charging
+          if self.battery.nil? # basic integrity check
+            self.battery = capacity
+          elsif self.power
+            capacity >= self.battery && self.battery = capacity
+          else
+            capacity <= self.battery && self.battery = capacity
+          end
+
+          self.power = charging
 
           rsc = self.get_image_path(self.power ? :battery_charge : :battery, self.battery)
 

--- a/lib/da_funk/helper/status_bar.rb
+++ b/lib/da_funk/helper/status_bar.rb
@@ -182,10 +182,14 @@ module DaFunk
 
           if self.battery.nil? # basic integrity check
             self.battery = capacity
-          elsif self.power
+          elsif charging
             capacity >= self.battery && self.battery = capacity
           else
             capacity <= self.battery && self.battery = capacity
+          end
+
+          if self.power == charging && capacity != self.battery
+            return nil
           end
 
           self.power = charging
@@ -194,7 +198,7 @@ module DaFunk
 
           Device::Display.print_status_bar(SLOT_BATTERY_LEVEL, rsc)
 
-          if capacity_type == 'percentage'
+          if capacity_type == 'percentage' || !self.power
             rsc = self.get_image_path(:battery_percentual, self.battery)
 
             Device::Display.print_status_bar(SLOT_BATTERY_PERCENTUAL, rsc)

--- a/lib/da_funk/helper/status_bar.rb
+++ b/lib/da_funk/helper/status_bar.rb
@@ -200,9 +200,11 @@ module DaFunk
 
           if capacity_type == 'percentage' || !self.power
             rsc = self.get_image_path(:battery_percentual, self.battery)
-
-            Device::Display.print_status_bar(SLOT_BATTERY_PERCENTUAL, rsc)
+          else
+            rsc = nil
           end
+
+          Device::Display.print_status_bar(SLOT_BATTERY_PERCENTUAL, rsc)
         end
       end
 

--- a/lib/device/system.rb
+++ b/lib/device/system.rb
@@ -45,6 +45,15 @@ class Device
       adapter.battery
     end
 
+    # Checks the type of the battery capacity return (percentage or scale).
+    def self.battery_capacity_type
+      begin
+        adapter.battery_capacity_type
+      rescue StandardError => exception
+        'scale'
+      end
+    end
+
     def self.beep
       adapter.beep
     end


### PR DESCRIPTION
This PR is part of the [CCT-257](https://cloudwalk.atlassian.net/browse/CCT-257) task, strictly related to [PR #12](https://github.com/cloudwalk/mruby-pax/pull/12) from mruby-pax. It's an important update to DaFunk, **made to be retrocompatible and _somewhat_ standalone**.

Code changes mainly contemplates:
- Full review of battery capacity resource files
- Full review of the `change_battery` method
- `battery_capacity_type` method creation (retrocompatible)

This PR is inevitably related to [PR #48](https://github.com/cloudwalk/main/pull/48) from `main`

P.S. I ended up mixing a commit to this PR that is not related to CCT-257 in any way. It's a small update for `lib/da_funk/rake_task.rb`, to help avoid flushing disposable error messages under the Windows Command Prompt. Since I was going to create a PR for this update anyway, I ask you to review it too (I promise to avoid such mistakes in future PRs).