### PR TITLE
Added method Device::IO#get_format_or_touchscreen_action

### DIFF
--- a/lib/device/io.rb
+++ b/lib/device/io.rb
@@ -161,7 +161,7 @@ class Device
       end
     end
 
-    def self.get_format_or_touchscreen_action(min, max, touch_map, options = {})
+    def self.get_format_or_touchscreen_action(max, touch_map, options = {})
       set_default_format_option(options)
       key = text = options[:value] || ""
       time = Time.now + (options[:timeout] || 30000) / 1000

--- a/lib/device/io.rb
+++ b/lib/device/io.rb
@@ -174,7 +174,8 @@ class Device
         if line_x && line_y
           ret = parse_touchscreen(touch_map, line_x, line_y)
           break(ret) if ret.include?(:touch_action)
-        elsif key = getc(100)
+        else
+          key = getc(100)
           if key == BACK
             text = text[0..-2]
             Device::Display.clear options[:line]


### PR DESCRIPTION
Device::IO#get_format_or_touchscreen_action has the ability of write a formatted text and capture a touchscreen event and return the action related with the touchscreen event.